### PR TITLE
refactor: enhance limit order cancellation and retrieval logic

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -20,7 +20,6 @@
     "create-token": "ts-node src/create-token-example.ts",
     "knowledge": "ts-node src/knowledge-example.ts",
     "wallet": "ts-node src/wallet-example.ts",
-    "limit-order": "ts-node src/limit-order-example.ts",
     "transfer": "ts-node src/transfer-example.ts",
     "build": "tsc",
     "swap-jupiter": "ts-node src/swap-example-jupiter.ts",

--- a/examples/basic/src/cancel-limit-order-example-thena.ts
+++ b/examples/basic/src/cancel-limit-order-example-thena.ts
@@ -178,7 +178,7 @@ async function main() {
   console.log(`Example 2: cancel limit order 123456 via thena on bnb`);
   const result2 = await agent.execute({
     input: `
-       cancel limit order 123456 via thena on bnb
+       cancel all limit order via thena on bnb
       `,
   });
   console.log('✓ cancel limit order result:', result2, '\n');

--- a/examples/basic/src/get-limit-order-example-thena.ts
+++ b/examples/basic/src/get-limit-order-example-thena.ts
@@ -16,7 +16,7 @@ import { TokenPlugin } from '@binkai/token-plugin';
 import { BnbProvider } from '@binkai/rpc-provider';
 
 // Hardcoded RPC URLs for demonstration
-const BNB_RPC = 'https://bsc-dataseed1.binance.org';
+const BNB_RPC = 'https://binance.llamarpc.com';
 const ETH_RPC = 'https://eth.llamarpc.com';
 
 async function main() {

--- a/examples/basic/src/limit-order-example-thena.ts
+++ b/examples/basic/src/limit-order-example-thena.ts
@@ -164,7 +164,7 @@ async function main() {
   console.log('Example 1:sell 0.02 BNB to USDC at price 700 via thena ');
   const result1 = await agent.execute({
     input: `
-     swap 0.02 BNB to USDC at price 700 via thena 
+     swap 0.02 BNB to USDC at price 700 
     `,
   });
   console.log('✓ limit order result:', result1, '\n');

--- a/packages/plugins/swap/src/GetLimitOrdersTool.ts
+++ b/packages/plugins/swap/src/GetLimitOrdersTool.ts
@@ -189,7 +189,6 @@ export class GetLimitOrdersTool extends BaseTool {
 
           // Retrieve orders from each network and provider
           const allOrders = await selectedProvider.getAllOrderIds(userAddress);
-          console.log('🤖 All orders:', allOrders);
 
           onProgress?.({
             progress: 70,
@@ -198,18 +197,25 @@ export class GetLimitOrdersTool extends BaseTool {
 
           // Validate each order
           let validatedCount = 0;
-          const validOrders = await Promise.all(
-            allOrders.map(async (orderId, index) => {
-              onProgress?.({
-                progress: 70 + Math.floor((index / allOrders.length) * 25),
-                message: `Validating order ${index + 1}/${allOrders.length}...`,
-              });
+          const validOrders = [];
 
+          for (let i = 0; i < allOrders.length; i++) {
+            const orderId = allOrders[i];
+            onProgress?.({
+              progress: 70 + Math.floor((i / allOrders.length) * 25),
+              message: `Validating order ${i + 1}/${allOrders.length}...`,
+            });
+
+            try {
               const isValid = await selectedProvider.checkValidOrderId(orderId);
-              validatedCount += isValid ? 1 : 0;
-              return isValid ? orderId : null;
-            }),
-          ).then(orders => orders.filter(Boolean));
+              if (isValid) {
+                validatedCount++;
+                validOrders.push(orderId);
+              }
+            } catch (error) {
+              console.error(`Error validating order ${orderId}:`, error);
+            }
+          }
 
           onProgress?.({
             progress: 95,

--- a/packages/plugins/swap/src/SwapTool.ts
+++ b/packages/plugins/swap/src/SwapTool.ts
@@ -277,6 +277,39 @@ export class SwapTool extends BaseTool {
             message: 'Searching for the best exchange rate for your swap.',
           });
 
+          // STEP 5: Handle wrapped token BNB
+          // validate is valid limit order
+          if (swapParams?.limitPrice && swapParams.fromToken === EVM_NATIVE_TOKEN_ADDRESS) {
+            onProgress?.({
+              progress: 5,
+              message: `Wrapping BNB to WBNB`,
+            });
+
+            selectedProvider = this.registry.getProvider(preferredProvider);
+            const wrapTx = await selectedProvider.wrapToken(amount.toString(), WrapToken.WBNB);
+
+            const wallet = this.agent.getWallet();
+            const wrapReceipt = await wallet.signAndSendTransaction(network, {
+              to: wrapTx.to,
+              data: wrapTx.data,
+              value: BigInt(wrapTx.value),
+            });
+
+            // Wait for approval to be mined
+            const wrapResult = await wrapReceipt.wait();
+
+            if (!wrapResult?.hash) {
+              throw new Error(`Failed to wrap BNB to WBNB`);
+            }
+            // set wrap token address
+            swapParams.fromToken = WrapToken.WBNB;
+
+            onProgress?.({
+              progress: 8,
+              message: `Successfully wrapped BNB to WBNB`,
+            });
+          }
+
           // STEP 4: Get provider and quote
           try {
             if (preferredProvider) {
@@ -293,38 +326,6 @@ export class SwapTool extends BaseTool {
                     providerSupportedNetworks: selectedProvider.getSupportedNetworks(),
                   },
                 );
-              }
-
-              // STEP 5: Handle wrapped token BNB
-              // validate is valid limit order
-              if (swapParams?.limitPrice && swapParams.fromToken === EVM_NATIVE_TOKEN_ADDRESS) {
-                onProgress?.({
-                  progress: 5,
-                  message: `Wrapping BNB to WBNB`,
-                });
-
-                const wrapTx = await selectedProvider.wrapToken(amount.toString(), WrapToken.WBNB);
-
-                const wallet = this.agent.getWallet();
-                const wrapReceipt = await wallet.signAndSendTransaction(network, {
-                  to: wrapTx.to,
-                  data: wrapTx.data,
-                  value: BigInt(wrapTx.value),
-                });
-
-                // Wait for approval to be mined
-                const wrapResult = await wrapReceipt.wait();
-
-                if (!wrapResult?.hash) {
-                  throw new Error(`Failed to wrap BNB to WBNB`);
-                }
-                // set wrap token address
-                swapParams.fromToken = WrapToken.WBNB;
-
-                onProgress?.({
-                  progress: 8,
-                  message: `Successfully wrapped BNB to WBNB`,
-                });
               }
 
               try {

--- a/packages/plugins/swap/src/SwapTool.ts
+++ b/packages/plugins/swap/src/SwapTool.ts
@@ -271,7 +271,6 @@ export class SwapTool extends BaseTool {
           };
           let selectedProvider: ISwapProvider;
           let quote: SwapQuote;
-          let isWrapToken = false;
 
           onProgress?.({
             progress: 0,
@@ -293,6 +292,14 @@ export class SwapTool extends BaseTool {
                     requestedNetwork: network,
                     providerSupportedNetworks: selectedProvider.getSupportedNetworks(),
                   },
+                );
+              }
+
+              //check limit order only support thena provider
+              if (swapParams?.limitPrice && selectedProvider.getName() !== 'thena') {
+                throw this.createError(
+                  ErrorStep.PROVIDER_VALIDATION,
+                  `Provider ${selectedProvider.getName()} does not support limit order.`,
                 );
               }
 
@@ -321,7 +328,6 @@ export class SwapTool extends BaseTool {
                 }
                 // set wrap token address
                 swapParams.fromToken = WrapToken.WBNB;
-                isWrapToken = true;
 
                 onProgress?.({
                   progress: 8,
@@ -467,7 +473,7 @@ export class SwapTool extends BaseTool {
           }
 
           // STEP 9: unwrap token if needed
-          // if (swapParams?.limitPrice && swapParams.fromToken === WrapToken.WBNB && isWrapToken) {
+          // if (swapParams?.limitPrice && swapParams.fromToken === WrapToken.WBNB) {
           //   const wallet = this.agent.getWallet();
           //   userAddress = await wallet.getAddress(network);
           //   onProgress?.({

--- a/packages/plugins/swap/src/SwapTool.ts
+++ b/packages/plugins/swap/src/SwapTool.ts
@@ -295,14 +295,6 @@ export class SwapTool extends BaseTool {
                 );
               }
 
-              //check limit order only support thena provider
-              if (swapParams?.limitPrice && selectedProvider.getName() !== 'thena') {
-                throw this.createError(
-                  ErrorStep.PROVIDER_VALIDATION,
-                  `Provider ${selectedProvider.getName()} does not support limit order.`,
-                );
-              }
-
               // STEP 5: Handle wrapped token BNB
               // validate is valid limit order
               if (swapParams?.limitPrice && swapParams.fromToken === EVM_NATIVE_TOKEN_ADDRESS) {

--- a/packages/providers/four-meme/src/FourMemeProvider.ts
+++ b/packages/providers/four-meme/src/FourMemeProvider.ts
@@ -119,6 +119,11 @@ export class FourMemeProvider extends BaseSwapProvider {
 
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
+      // check is valid limit order
+      if (params?.limitPrice) {
+        throw new Error('FourMeme does not support limit order for native token swaps');
+      }
+
       const [tokenIn, tokenOut] = await Promise.all([
         this.getToken(params.fromToken, params.network),
         this.getToken(params.toToken, params.network),

--- a/packages/providers/jupiter/src/JupiterProvider.ts
+++ b/packages/providers/jupiter/src/JupiterProvider.ts
@@ -190,6 +190,11 @@ export class JupiterProvider extends BaseSwapProvider {
 
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
+      // check is valid limit order
+      if (params?.limitPrice) {
+        throw new Error('Jupiter does not support limit order for native token swaps');
+      }
+
       const [sourceToken, destinationToken] = await Promise.all([
         this.getToken(params.fromToken, params.network),
         this.getToken(params.toToken, params.network),

--- a/packages/providers/kyber/src/KyberProvider.ts
+++ b/packages/providers/kyber/src/KyberProvider.ts
@@ -109,6 +109,11 @@ export class KyberProvider extends BaseSwapProvider {
   // }
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
+      // check is valid limit order
+      if (params?.limitPrice) {
+        throw new Error('Kyber does not support limit order for native token swaps');
+      }
+
       // Fetch input and output token information
       const [sourceToken, destinationToken] = await Promise.all([
         this.getToken(params.fromToken, params.network),

--- a/packages/providers/oku/src/OkuProvider.ts
+++ b/packages/providers/oku/src/OkuProvider.ts
@@ -70,6 +70,11 @@ export class OkuProvider extends BaseSwapProvider {
   }
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
+      // check is valid limit order
+      if (params?.limitPrice) {
+        throw new Error('OKU does not support limit order for native token swaps');
+      }
+
       if (params.type === 'output') {
         throw new Error('OKU does not support output swaps');
       }

--- a/packages/providers/okx/src/OkxProvider.ts
+++ b/packages/providers/okx/src/OkxProvider.ts
@@ -92,6 +92,11 @@ export class OkxProvider extends BaseSwapProvider {
 
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
+      // check is valid limit order
+      if (params?.limitPrice) {
+        throw new Error('OKX does not support limit order for native token swaps');
+      }
+
       if (params.type === 'output') {
         throw new Error('OKX does not support output swaps');
       }

--- a/packages/providers/pancakeswap/src/PancakeSwapProvider.ts
+++ b/packages/providers/pancakeswap/src/PancakeSwapProvider.ts
@@ -84,6 +84,11 @@ export class PancakeSwapProvider extends BaseSwapProvider {
 
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
+      // check is valid limit order
+      if (params?.limitPrice) {
+        throw new Error('PancakeSwap does not support limit order for native token swaps');
+      }
+
       if (params.fromToken === Native.onChain(this.chainId).wrapped.address) {
         params.fromToken = EVM_NATIVE_TOKEN_ADDRESS;
       }


### PR DESCRIPTION
- Updated `CancelLimitOrdersTool` to support cancellation of all pending orders by adding 'all' as a valid order ID option.
- Modified example command in `cancel-limit-order-example-thena` to reflect the new cancellation capability.
- Changed the RPC URL in `get-limit-order-example-thena` for improved reliability.
- Improved order validation process in `GetLimitOrdersTool` to handle errors more gracefully during order validation.