### PR TITLE
refactor: remove unsupported limit order check in getQuote method of …

### DIFF
--- a/packages/providers/jupiter/src/JupiterProvider.ts
+++ b/packages/providers/jupiter/src/JupiterProvider.ts
@@ -294,11 +294,6 @@ export class JupiterProvider extends BaseSwapProvider {
 
   async getQuote(params: SwapParams, userAddress: string): Promise<SwapQuote> {
     try {
-      // check is valid limit order
-      if (params?.limitPrice) {
-        throw new Error('Jupiter does not support limit order for native token swaps');
-      }
-
       const [sourceToken, destinationToken] = await Promise.all([
         this.getToken(params.fromToken, params.network),
         this.getToken(params.toToken, params.network),


### PR DESCRIPTION
…JupiterProvider

- Eliminated the check for limit orders in the getQuote method, as Jupiter does not support limit orders for native token swaps, improving code clarity.