### PR TITLE
fix: validate limitPrice to ensure it's not zero in swap providers

### DIFF
--- a/packages/plugins/swap/src/SwapTool.ts
+++ b/packages/plugins/swap/src/SwapTool.ts
@@ -279,7 +279,11 @@ export class SwapTool extends BaseTool {
 
           // STEP 5: Handle wrapped token BNB
           // validate is valid limit order
-          if (swapParams?.limitPrice && swapParams.fromToken === EVM_NATIVE_TOKEN_ADDRESS) {
+          if (
+            swapParams?.limitPrice &&
+            swapParams.fromToken === EVM_NATIVE_TOKEN_ADDRESS &&
+            Number(swapParams?.limitPrice) !== 0
+          ) {
             onProgress?.({
               progress: 5,
               message: `Wrapping BNB to WBNB`,

--- a/packages/providers/jupiter/src/JupiterProvider.ts
+++ b/packages/providers/jupiter/src/JupiterProvider.ts
@@ -318,7 +318,7 @@ export class JupiterProvider extends BaseSwapProvider {
       let swapData;
       let getSwapBuyAggregator;
 
-      if (params?.limitPrice) {
+      if (params?.limitPrice && Number(params?.limitPrice) !== 0) {
         swapData = await this.getQuoteJupiter(
           {
             inputMint: new PublicKey(sourceToken.address),

--- a/packages/providers/thena/src/ThenaProvider.ts
+++ b/packages/providers/thena/src/ThenaProvider.ts
@@ -117,7 +117,7 @@ export class ThenaProvider extends BaseSwapProvider {
       let swapTransactionData;
 
       let optimalRoute;
-      if (params?.limitPrice) {
+      if (params?.limitPrice && Number(params?.limitPrice) !== 0) {
         swapTransactionData = null;
 
         // Fetch optimal limit order route


### PR DESCRIPTION
- Updated the condition for limitPrice checks in SwapTool, JupiterProvider, and ThenaProvider to include a check that limitPrice is not equal to zero, preventing unnecessary operations.